### PR TITLE
change text  cancel to message

### DIFF
--- a/lib/adapters/xhr.js
+++ b/lib/adapters/xhr.js
@@ -170,13 +170,13 @@ module.exports = function xhrAdapter(config) {
 
     if (config.cancelToken) {
       // Handle cancellation
-      config.cancelToken.promise.then(function onCanceled(cancel) {
+      config.cancelToken.promise.then(function onCanceled(message) {
         if (!request) {
           return;
         }
 
         request.abort();
-        reject(cancel);
+        reject(message);
         // Clean up request
         request = null;
       });


### PR DESCRIPTION
There is a problem with semantics. The parameters of the onCanceled method should be message instead of cancel.
